### PR TITLE
Check wgTitle before use

### DIFF
--- a/includes/ApprovedRevs_body.php
+++ b/includes/ApprovedRevs_body.php
@@ -22,7 +22,7 @@ class ApprovedRevs {
 		"File", "MediaWiki", "Category"
 	);
 	static $banned_NS_IDs = false; // requires initialization
-	
+
 	/**
 	 * Gets the approved revision ID for this page, or null if there isn't
 	 * one.
@@ -127,7 +127,7 @@ class ApprovedRevs {
 		}
 
 		if ( !$title->exists() ) {
-			return $title->isApprovable = false;			
+			return $title->isApprovable = false;
 		}
 
 
@@ -154,29 +154,29 @@ class ApprovedRevs {
 			return $title->isApprovable = true;
 
 		// FIXME: Jamesmontalvo3 question/discussion:
-		// Regarding below: not sure if we should keep this. It seems cleaner to say you can add 
+		// Regarding below: not sure if we should keep this. It seems cleaner to say you can add
 		// the approval-requirement on a case-by-case basis via the approvedrevs-permissions page
-		// than to allow any user to throw __APPROVEDREVS__ onto a page. Also, with the new 
-		// implementation only people with "All Pages" permissions (probably just sysops in most 
+		// than to allow any user to throw __APPROVEDREVS__ onto a page. Also, with the new
+		// implementation only people with "All Pages" permissions (probably just sysops in most
 		// cases) will be able to approve this. Rather than adding __APPROVEDREVS__ instead add
-		// [[Category:Pages with Approved Revisions]] (or similar category) which can more finely 
+		// [[Category:Pages with Approved Revisions]] (or similar category) which can more finely
 		// limit who can have permissions
 		// --------------------------------------------------------------------
-		// it doesn't satisfy mediawiki:approvedrevs-permissions, so check 
+		// it doesn't satisfy mediawiki:approvedrevs-permissions, so check
 		// for the page property - for some reason, calling the standard
 		// getProperty() function doesn't work, so we just do a DB
 		// query on the page_props table
 		if ( ( ! $is_media ) && self::pageHasMagicWord( $title ) )
 			return $title->isApprovable = true;
-		
-		// if a page already has an approval, it must be approvable in order to be able to 
+
+		// if a page already has an approval, it must be approvable in order to be able to
 		// view/modify approvals. Though this wasn't the case on previous versions of ApprovedRevs,
 		// it is necessary now since which pages can be approved can change much more easily
 		if ( $is_media ) {
 			list($ts,$sha1) = self::GetApprovedFileInfo( $title ); // if title in approved_revs_files table
 			if ($ts !== false) {
-				// only approvable because it already has an approved rev, not because it is in 
-				// message "approvedrev-permissions" 
+				// only approvable because it already has an approved rev, not because it is in
+				// message "approvedrev-permissions"
 				$title->isGrandfatheredApprovable = true; // FIXME: where is this used? change name.
 				return $title->isApprovable = true;
 			}
@@ -189,7 +189,7 @@ class ApprovedRevs {
 
 
 	}
-	
+
 	public static function mediaIsApprovable ( Title $title ) {
 		return self::pageIsApprovable( $title, true ); // use pageIsApprovable() with files allowed
 	}
@@ -199,10 +199,10 @@ class ApprovedRevs {
 
 		if ( in_array( self::getNamespaceName( $title ), $perms['Namespaces'] ) )
 			return true;
-		else 
+		else
 			return false;
 	}
-	
+
 	public static function titleInCategoryPermissions ( $title ) {
 		$perms = self::getPermissions();
 
@@ -210,11 +210,11 @@ class ApprovedRevs {
 			return true;
 		else
 			return false;
-	}	
-	
+	}
+
 	public static function titleInPagePermissions ( $title ) {
 		$perms = self::getPermissions();
-		
+
 		if ( in_array( $title->getText(), $perms['Pages'] ) )
 			return true;
 		elseif ( in_array( $title->getNsText().':'.$title->getText(), $perms['Pages'] ) )
@@ -222,10 +222,10 @@ class ApprovedRevs {
 		else
 			return false;
 	}
-	
+
 	// check if page has __APPROVEDREVS__
 	public static function pageHasMagicWord ( $title ) {
-	
+
 		// END OF MY SECTION
 
 		// It's not in an included namespace, so check for the page
@@ -246,7 +246,7 @@ class ApprovedRevs {
 		else
 			return false;
 	}
-	
+
 	public static function getTitleApprovableCategories ( $title ) {
 		$perms = self::getPermissions();
 		return array_intersect( self::getCategoryList( $title ), $perms['Categories'] );
@@ -263,14 +263,14 @@ class ApprovedRevs {
 		// self::$mwTitleObj = $title;
 		// Jamesmontalvo3: After reading through more of the code I think this may break in some cases...
 		// TODO: rework w/o self::$mwTitleObj if required - rework may be complete...leaving this here until I get the extension working again
-		
-		
+
+
 		$page_ns     = self::getNamespaceName( $title );
 		$page_cats   = self::getCategoryList( $title );
 		$page_actual = $title->getText();
 		if ($page_ns != 'Main')
 			$page_actual = $page_ns . ':' . $page_actual;
-				
+
 		$permissions = self::getPermissions();
 
 		if ( self::checkIfUserInPerms($permissions['All Pages']) )
@@ -292,7 +292,7 @@ class ApprovedRevs {
 			if ( in_array($cat, $page_cats) )
 				self::checkIfUserInPerms( $perms, $inclusive );
 		}
-		
+
 		foreach ($permissions['Page Permissions'] as $pg => $perms) {
 			if ($pg[0]==='+') {
 				$inclusive = true;
@@ -304,11 +304,11 @@ class ApprovedRevs {
 			if ($pg == $page_actual)
 				self::checkIfUserInPerms( $perms, $inclusive );
 		}
-		
+
 		if ( self::usernameIsBasePageName() )
 			self::$mUserCanApprove = true;
 
-		
+
 		return self::$mUserCanApprove;
 	}
 
@@ -413,39 +413,39 @@ class ApprovedRevs {
 		global $wgOut;
 		$wgOut->addModuleStyles( 'ext.ApprovedRevs' );
 	}
-	
-	
+
+
 	/**
 	 *  All methods below are totally new from jamesmontalvo3
 	 **/
-		
+
 	// pull INI-file content from approvedrevs-permissions
 	public static function getPermissions () {
 
 		if ( self::$permissions )
 			return self::$permissions;
-			
+
 		preg_match_all(
-			'/<syntaxhighlight lang="INI">(.*?)<\/syntaxhighlight>/si', 
-			wfMessage( 'approvedrevs-permissions' )->text(), 
+			'/<syntaxhighlight lang="INI">(.*?)<\/syntaxhighlight>/si',
+			wfMessage( 'approvedrevs-permissions' )->text(),
 			$matches);
-				
+
 		self::$permissions = parse_ini_string( $matches[1][0], true );
-				
+
 		// create arrays of N/C/P's for quickly checking if page is approvable
 		self::$permissions['Namespaces'] = array();
 		self::$permissions['Categories'] = array();
 		self::$permissions['Pages']      = array();
-		
+
 		foreach(self::$permissions['Namespace Permissions'] as $ns => $perms)
 			array_push(self::$permissions['Namespaces'], $ns);
-		
+
 		foreach(self::$permissions['Category Permissions'] as $cat => $perms)
 			array_push(self::$permissions['Categories'], ($cat[0]=='+')?substr($cat,1):$cat );
-		
+
 		foreach(self::$permissions['Page Permissions'] as $pg => $perms)
 			array_push(self::$permissions['Pages'], ($pg[0]=='+')?substr($pg,1):$pg );
-			
+
 		return self::$permissions;
 
 	}
@@ -457,19 +457,19 @@ class ApprovedRevs {
 		// can approve, no need to check further
 		if ( $inclusive == true && self::$mUserCanApprove == true)
 			return true;
-			
+
 		// Is like: ["User:John", "User:Jen", "Group:sysop", "Self", "Creator", "Property:Reviewer"]
 		// Thought about strtolower-ing all of this, but "Property:Prop Name" needs to maintain
 		// character case.
 		$perms = explode( ',' , $perms );
-		
+
 		$userGroups = array_map('strtolower',$wgUser->getGroups());
-		
+
 		foreach($perms as $perm) {
-		
+
 			// $perm[0] == perm type, $perm[1] == perm value (if applicable)
 			$perm = explode(':', $perm);
-			
+
 			switch ( strtolower(trim($perm[0])) ) {
 				case "user":
 					if ( strtolower(trim($perm[1])) === strtolower($wgUser->getName()) )
@@ -490,13 +490,13 @@ class ApprovedRevs {
 				case "": // skip lines w/o perms (i.e. lines like "Main = ")
 					break;
 				default:
-					throw new MWException(__METHOD__ 
+					throw new MWException(__METHOD__
 						. '(): invalid permissions type');
 			}
 		}
-				
+
 		// if $inclusive==true, the fact that this call to checkIfUserInPerms() didn't find a match does
-		// not mean that that the user is denied. Instead return the unmodified value of  
+		// not mean that that the user is denied. Instead return the unmodified value of
 		// self::$mUserCanApprove, which could be either true or false depending on previous passes
 		// through checkIfUserInPerms()
 		if ($inclusive)
@@ -504,13 +504,13 @@ class ApprovedRevs {
 			// wouldn't it have been caught at beginning of function?
 			return self::$mUserCanApprove;
 
-		// if $inclusive==false, the previous value of $mUserCanApprove is irrelevant. return false 
+		// if $inclusive==false, the previous value of $mUserCanApprove is irrelevant. return false
 		// since no matches were found here (still could be overridden by later passes)
 		else
 			return self::$mUserCanApprove = false;
-		
+
 	}
-	
+
 	// returns true if $wgUser was the user who created the page
 	public static function isPageCreator () {
 		global $wgUser, $wgTitle;
@@ -527,38 +527,42 @@ class ApprovedRevs {
 		return $row->rev_user_text == $wgUser->getName();
 	}
 
-	// Determines if username is the base pagename, e.g. if user is User:Jamesmontalvo3 then this 
+	// Determines if username is the base pagename, e.g. if user is User:Jamesmontalvo3 then this
 	// returns true for pages named User:Jamesmontalvo3, User:Jamesmontalvo3/Subpage, etc
 	// This is for use with the "Self" keyword in approvedrevs-permissions.
 	public static function usernameIsBasePageName () {
 		global $wgUser, $wgTitle;
 
+		if ( ! $wgTitle || ! is_a( $wgTitle, 'Title' ) ) {
+			return false;
+		}
+
 		if ($wgTitle->getNamespace() == NS_USER || $wgTitle->getNamespace() == NS_USER_TALK) {
-		
+
 			// explode on slash to just get the first part (if it is a subpage)
 			// as far as I know usernames cannot have slashes in them, so this should be okay
 			$title_parts = explode('/', $wgTitle->getText()); // no array dereference in PHP < 5.4 :-(
-			
+
 			// sticking with case-sensitive here. So username "James Montalvo" won't have "Self" rights
 			// on page "User:James montalvo". I think that's the right move
 			return $title_parts[0] == $wgUser->getName();
-		
+
 		}
 		return false;
 	}
-	
+
 	public static function getNamespaceIDfromName ( $nsName ) {
 		if ($nsName == "Main")
 			$nsName = "";
-			
+
 		$page_ns = MWNamespace::getCanonicalNamespaces();
 		foreach($page_ns as $id => $name) {
 			if ($nsName == $name)
 				return $id;
 		}
 		return false; // invalid name, nonexistant namespace
-		
-		
+
+
 		$page_ns = $page_ns[ $nsName ]; // NS text
 		if ($page_ns == "")
 			$page_ns = "Main";
@@ -578,9 +582,9 @@ class ApprovedRevs {
 
 	public static function getCategoryList ( $title ) {
 		$catTree = $title->getParentCategoryTree();
-		return array_unique( self::getCategoryListHelper($catTree) );		
+		return array_unique( self::getCategoryListHelper($catTree) );
 	}
-	
+
 	public static function getCategoryListHelper ( $catTree ) {
 
 		$out = array();
@@ -591,19 +595,19 @@ class ApprovedRevs {
 				array_merge($out, self::getCategoryListHelper( $parentCats ));
 		}
 		return $out;
-	
+
 	}
 
 	public static function smwPropertyEqualsCurrentUser ( $userProperty ) {
 		global $wgTitle, $wgUser;
-				
+
 		if ( ! class_exists('SMWHooks') ) // if semantic not installed
 			die('Semantic MediaWiki must be installed to use the ApprovedRevs "Property" definition.');
-		else {	
-			$valueDis = smwfGetStore()->getPropertyValues( 
+		else {
+			$valueDis = smwfGetStore()->getPropertyValues(
 				new SMWDIWikiPage( $wgTitle->getDBkey(), $wgTitle->getNamespace(), '' ),
 				new SMWDIProperty( SMWPropertyValue::makeUserProperty( $userProperty )->getDBkey() ) );   // trim($userProperty)
-			
+
 			foreach ($valueDis as $valueDI) {
 				if ( ! $valueDI instanceof SMWDIWikiPage )
 					throw new Exception('ApprovedRevs "Property" permissions must use Semantic MediaWiki properties of type "Page"');
@@ -613,33 +617,33 @@ class ApprovedRevs {
 		}
 		return false;
 	}
-	
-	
-	
+
+
+
 	public static function SetApprovedFileInDB ( $title, $timestamp, $sha1 ) {
 
 		$dbr = wfGetDB( DB_MASTER );
 		$file_title = $title->getDBkey();
 		$old_file_title = $dbr->selectField( 'approved_revs_files', 'file_title', array( 'file_title' => $file_title ) );
 		if ( $old_file_title ) {
-			$dbr->update( 'approved_revs_files', 
+			$dbr->update( 'approved_revs_files',
 				array( 'approved_timestamp' => $timestamp, 'approved_sha1' => $sha1 ), // update fields
 				array( 'file_title' => $file_title )
 			);
 		} else {
 			$dbr->insert( 'approved_revs_files',
-				array( 'file_title' => $file_title, 'approved_timestamp' => $timestamp, 'approved_sha1' => $sha1 ) 
+				array( 'file_title' => $file_title, 'approved_timestamp' => $timestamp, 'approved_sha1' => $sha1 )
 			);
 		}
 		// Update "cache" in memory
 		self::$mApprovedFileInfo[$file_title] = array( $timestamp, $sha1 );
 
 		$log = new LogPage( 'approval' );
-				
+
 		$imagepage = ImagePage::newFromID( $title->getArticleID() );
 		$display_file_url = $imagepage->getDisplayedFile()->getFullURL();
 		// $url = $title->getDisplayedFile()->getFullURL(); // link to the imagepage, or directly to the approved file?
-		
+
 		// $url = $file_obj->getFullURL();
 		$rev_link = Xml::element(
 			'a',
@@ -660,9 +664,9 @@ class ApprovedRevs {
 	}
 
 	public static function UnsetApprovedFileInDB ( $title ) {
-		
+
 		$file_title = $title->getDBkey();
-		
+
 		$dbr = wfGetDB( DB_MASTER );
 		$dbr->delete( 'approved_revs_files', array( 'file_title' => $file_title ) );
 		// the unapprove page method had LinksUpdate and Parser objects here, but the page text has
@@ -688,11 +692,11 @@ class ApprovedRevs {
 
 		if ( isset(self::$mApprovedFileInfo[ $file_title->getDBkey() ]) )
 			return self::$mApprovedFileInfo[ $file_title->getDBkey() ];
-	
+
 		$dbr = wfGetDB( DB_SLAVE );
 		$row = $dbr->selectRow(
 			'approved_revs_files', // select from table
-			array('approved_timestamp', 'approved_sha1'), 
+			array('approved_timestamp', 'approved_sha1'),
 			array( 'file_title' => $file_title->getDBkey() )
 		);
 		if ( $row )
@@ -702,7 +706,7 @@ class ApprovedRevs {
 
 		self::$mApprovedFileInfo[ $file_title->getDBkey() ] = $return;
 		return $return;
-		
+
 	}
 
 	public static function getPermissionsStringsForDB () {
@@ -730,26 +734,26 @@ class ApprovedRevs {
 			$title = Title::newFromText( $pg );
 			$pgIDs[] = $title->getArticleID();
 		}
-		
-		return array( 
+
+		return array(
 			count($nsIDs) > 0   ? implode(',', $nsIDs)   : false,
 			count($catCols) > 0 ? implode(',', $catCols) : false,
 			count($pgIDs) > 0   ? implode(',', $pgIDs)   : false,
 		);
-		
+
 	}
-	
+
 	public static function getBannedNamespaceIDs () {
-		
+
 		if ( self::$banned_NS_IDs !== false )
 			return self::$banned_NS_IDs;
-		
+
 		self::$banned_NS_IDs = array();
 		foreach(self::$banned_NS_names as $ns_name) {
 			self::$banned_NS_IDs[] = self::getNamespaceIDfromName($ns_name);
 		}
-		
+
 		return self::$banned_NS_IDs;
 	}
-	
+
 }


### PR DESCRIPTION
Perform checks that `$wgTitle` is set and is of class `Title` prior to use. This was causing failures in maintenance scripts.

Closes #4