### PR TITLE
Fix problem with mysql_real_escape_string

### DIFF
--- a/ApprovedRevs_body.php
+++ b/ApprovedRevs_body.php
@@ -698,11 +698,13 @@ class ApprovedRevs {
 
 		// using array of categories from $perms, create array of category
 		// names in the same form as categorylinks.cl_to
-		// FIXME: is mysql_real_escape_string the way to go? of does MW have something built in?
 		$catCols = array();
 		foreach($perms['Categories'] as $cat) {
 			$catObj = Category::newFromName( $cat );
-			$catCols[] = "'" . mysql_real_escape_string($catObj->getName()) . "'";
+			// FIXME: replaced mysql_real_escape_string with addcslashes with escaping on \, " and '
+			// mysql_real_escape_string also escapes \x00, \n, \r and \x1a. Do we need these? Not
+			// likely since $catObj is constructed from Category::newFromName.
+                        $catCols[] = "'" . addcslashes($catObj->getName(), "\\\"'") . "'";
 		}
 
 		$pgIDs = array();


### PR DESCRIPTION
The following errors were occurring when attempting to view "unapproved pages":

>Deprecated: mysql_real_escape_string(): The mysql extension is deprecated and will be removed in the future: use mysqli or PDO instead in /opt/meza/htdocs/mediawiki/extensions/ApprovedRevs/ApprovedRevs_body.php on line 705
Warning: mysql_real_escape_string(): Access denied for user ''@'localhost' (using password: NO) in /opt/meza/htdocs/mediawiki/extensions/ApprovedRevs/ApprovedRevs_body.php on line 705
Warning: mysql_real_escape_string(): A link to the server could not be established in /opt/meza/htdocs/mediawiki/extensions/ApprovedRevs/ApprovedRevs_body.php on line 705
Deprecated: mysql_real_escape_string(): The mysql extension is deprecated and will be removed in the future: use mysqli or PDO instead in /opt/meza/htdocs/mediawiki/extensions/ApprovedRevs/ApprovedRevs_body.php on line 705
Warning: mysql_real_escape_string(): Access denied for user ''@'localhost' (using password: NO) in /opt/meza/htdocs/mediawiki/extensions/ApprovedRevs/ApprovedRevs_body.php on line 705
Warning: mysql_real_escape_string(): A link to the server could not be established in /opt/meza/htdocs/mediawiki/extensions/ApprovedRevs/ApprovedRevs_body.php on line 705

Removal of [mysql_real_escape_string](http://php.net/manual/en/function.mysql-real-escape-string.php) was required. Instead it was replaced with [addcslashes](http://php.net/manual/en/function.addcslashes.php). Only a subset of what `mysql_real_escape_string` escapes was included, since the others are not likely in this case.