### PR TITLE
Check if page is valid before trying to get redirect target

### DIFF
--- a/ApprovedRevs.hooks.php
+++ b/ApprovedRevs.hooks.php
@@ -802,10 +802,11 @@ class ApprovedRevsHooks {
 			
 			// Media link redirects don't get caught by the normal redirect check, so this
 			// extra check is required
-			if ( $temp = WikiPage::newFromID($file_title->getArticleID())->getRedirectTarget() ) {
-				$file_title = $temp;
-				unset($temp);
+			$temp = WikiPage::newFromID( $file_title->getArticleID() );
+			if ( $temp && $temp->getRedirectTarget() ) {
+				$file_title = $temp->getTitle();
 			}
+			unset($temp);
 		}
 		
 		if ( $file_title->isRedirect() ) {


### PR DESCRIPTION
Issue where file page doesn't exist for media links, and thus can't determine redirect target of this nonexistent page.