### PR TITLE
Show the user who approved a page.

### DIFF
--- a/ApprovedRevs.css
+++ b/ApprovedRevs.css
@@ -39,3 +39,7 @@ tr.approved-revision td:last-child {
 	border:solid #aaa 1px;
 	padding: 3px 8px;
 }
+
+span.approvingUser {
+    display: block;
+}

--- a/ApprovedRevs.php
+++ b/ApprovedRevs.php
@@ -135,6 +135,8 @@ $wgGroupPermissions['sysop']['approverevisions'] = true;
  // used
 $wgAvailableRights[] = 'viewlinktolatest';
 $wgGroupPermissions['*']['viewlinktolatest'] = true;
+$wgAvailableRights[] = 'viewapprover';
+$wgGroupPermissions['sysop']['viewapprover'] = true;
 
 // ResourceLoader modules
 $wgResourceModules['ext.ApprovedRevs'] = array(

--- a/ApprovedRevs_body.php
+++ b/ApprovedRevs_body.php
@@ -12,6 +12,7 @@ class ApprovedRevs {
 
 	// Static arrays to prevent querying the database more than necessary.
 	static $mApprovedContentForPage = array();
+	static $mApprovedRevUserForPage = array();
 	static $mApprovedRevIDForPage = array();
 	static $mApprovedFileInfo = array();
 	static $mUserCanApprove = null;
@@ -21,6 +22,24 @@ class ApprovedRevs {
 	static $currentTitle = null;
 	static $currentUser = null;
 	static $bannedNamespaceIds = array( NS_FILE, NS_MEDIAWIKI, NS_CATEGORY );
+
+	/**
+	 * Gets the approved revision User for this page, or null if there isn't
+	 * one.
+	 */
+	public static function getApprovedRevUser( $title ) {
+		$pageID = $title->getArticleID();
+		if ( !isset( self::$mApprovedRevUserForPage[$pageID] ) && self::pageIsApprovable( $title ) ) {
+			$dbr = wfGetDB( DB_SLAVE );
+			$revUser = $dbr->selectField( 'approved_revs', 'appr_user',
+										  array( 'page_id' => $pageID ) );
+			if ( $revUser ) {
+				$revUser = User::newFromID( $revUser );
+			}
+			self::$mApprovedRevUserForPage[$pageID] = $revUser;
+		}
+		return $revUser;
+	}
 
 	/**
 	 * Gets the approved revision ID for this page, or null if there isn't
@@ -344,7 +363,16 @@ class ApprovedRevs {
 		return self::$mUserCanApprove;
 	}
 
-	public static function saveApprovedRevIDInDB( $title, $rev_id ) {
+	public static function saveApprovedRevIDInDB(
+		$title, $rev_id, $type = 'auto'
+	) {
+		global $wgUser;
+		$userBit = array();
+
+		if ( $type !== 'auto' ) {
+			$userBit = array( 'appr_user' => $wgUser->getID() );
+		}
+
 		$dbr = wfGetDB( DB_MASTER );
 		$page_id = $title->getArticleID();
 		$old_rev_id =
@@ -353,19 +381,19 @@ class ApprovedRevs {
 				array( 'page_id' => $page_id )
 			);
 		if ( $old_rev_id ) {
-			$dbr->update(
-				'approved_revs',
-				array( 'rev_id' => $rev_id ),
-				array( 'page_id' => $page_id )
-			);
+			$dbr->update( 'approved_revs',
+						  array_merge( array( 'rev_id' => $rev_id ), $userBit ),
+						  array( 'page_id' => $page_id ) );
 		} else {
-			$dbr->insert(
-				'approved_revs',
-				array( 'page_id' => $page_id, 'rev_id' => $rev_id )
-			);
+			$dbr->insert( 'approved_revs',
+						  array_merge(
+							  array( 'page_id' => $page_id, 'rev_id' => $rev_id ),
+							  $userBit
+						  ) );
 		}
 		// Update "cache" in memory
 		self::$mApprovedRevIDForPage[$page_id] = $rev_id;
+		self::$mApprovedRevUserForPage[$page_id] = $wgUser;
 	}
 
 	static function setPageSearchText( $title, $text ) {
@@ -382,8 +410,9 @@ class ApprovedRevs {
 	 * info for extensions such as Semantic MediaWiki; and logs the action.
 	 */
 	public static function setApprovedRevID(
-		$title, $rev_id, $is_latest = false ) {
-		self::saveApprovedRevIDInDB( $title, $rev_id );
+		$title, $rev_id, $is_latest = false
+	) {
+		self::saveApprovedRevIDInDB( $title, $rev_id, 'manual' );
 		$parser = new Parser();
 
 		// If the revision being approved is definitely the latest
@@ -468,7 +497,9 @@ class ApprovedRevs {
 	/**
 	 * Helper function for backward compatibility.
 	 */
-	public static function makeLink( $linkRenderer, $title, $msg = null, $attrs = array(), $params = array() ) {
+	public static function makeLink(
+		$linkRenderer, $title, $msg = null, $attrs = array(), $params = array()
+	) {
 		if ( !is_null( $linkRenderer ) ) {
 			// MW 1.28+
 			return $linkRenderer->makeLink( $title, $msg, $attrs, $params );

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,158 @@
+{
+	"@Note": "When updating this file please also update ApprovedRevs.php with the same changes.",
+	"name": "Approved Revs",
+	"version": "0.8-alpha",
+	"author": [
+		"Yaron Koren",
+		"..."
+	],
+	"url": "https://www.mediawiki.org/wiki/Extension:Approved_Revs",
+	"descriptionmsg": "approvedrevs-desc",
+	"license-name": "GPL-2.0-or-later",
+	"type": "hook",
+	"requires": {
+		"MediaWiki": ">= 1.27.0"
+	},
+	"GroupPermissions": {
+		"sysop": {
+			"viewapprover": true,
+			"approverevisions": true
+		},
+		"*": {
+			"viewlinktolatest": true
+		}
+	},
+	"AvailableRights": [
+		"approverevisions",
+		"viewlinktolatest",
+		"viewapprover"
+	],
+	"LogTypes": [
+		"approval"
+	],
+	"LogNames": {
+		"approval": "approvedrevs-logname"
+	},
+	"LogHeaders": {
+		"approval": "approvedrevs-logdesc"
+	},
+	"LogActions": {
+		"approval/approve": "approvedrevs-approveaction",
+		"approval/unapprove": "approvedrevs-unapproveaction"
+	},
+	"SpecialPages": {
+		"ApprovedRevs": "SpecialApprovedRevs"
+	},
+	"APIModules": {
+		"approve": "ApiApprove"
+	},
+	"MessagesDirs": {
+		"ApprovedRevs": [
+			"i18n"
+		]
+	},
+	"ExtensionMessagesFiles": {
+		"ApprovedRevsAlias": "ApprovedRevs.alias.php",
+		"ApprovedRevsMagic": "ApprovedRevs.i18n.magic.php"
+	},
+	"AutoloadClasses": {
+		"ApprovedRevs": "ApprovedRevs_body.php",
+		"ApprovedRevsHooks": "ApprovedRevs.hooks.php",
+		"SpecialApprovedRevs": "SpecialApprovedRevs.php",
+		"SpecialApprovedRevsPage": "SpecialApprovedRevsPage.php",
+		"ApiApprove": "ApiApprove.php"
+	},
+	"ResourceModules": {
+		"ext.ApprovedRevs": {
+			"styles": "ApprovedRevs.css"
+		}
+	},
+	"ResourceFileModulePaths": {
+		"localBasePath": "",
+		"remoteExtPath": "ApprovedRevs"
+	},
+	"Hooks": {
+		"ArticleEditUpdates": [
+			"ApprovedRevsHooks::updateLinksAfterEdit"
+		],
+		"PageContentSaveComplete": [
+			"ApprovedRevsHooks::setLatestAsApproved",
+			"ApprovedRevsHooks::setSearchText"
+		],
+		"SearchResultInitFromTitle": [
+			"ApprovedRevsHooks::setSearchRevisionID"
+		],
+		"PersonalUrls": [
+			"ApprovedRevsHooks::removeRobotsTag"
+		],
+		"ArticleFromTitle": [
+			"ApprovedRevsHooks::showApprovedRevision"
+		],
+		"ArticleAfterFetchContentObject": [
+			"ApprovedRevsHooks::showBlankIfUnapproved"
+		],
+		"DisplayOldSubtitle": [
+			"ApprovedRevsHooks::setSubtitle"
+		],
+		"SkinTemplateTabs": [
+			"ApprovedRevsHooks::changeEditLink"
+		],
+		"SkinTemplateNavigation": [
+			"ApprovedRevsHooks::changeEditLinkVector"
+		],
+		"PageHistoryBeforeList": [
+			"ApprovedRevsHooks::storeApprovedRevisionForHistoryPage"
+		],
+		"PageHistoryLineEnding": [
+			"ApprovedRevsHooks::addApprovalLink"
+		],
+		"UnknownAction": [
+			"ApprovedRevsHooks::setAsApproved",
+			"ApprovedRevsHooks::unsetAsApproved"
+		],
+		"BeforeParserFetchTemplateAndtitle": [
+			"ApprovedRevsHooks::setTranscludedPageRev"
+		],
+		"ArticleDeleteComplete": [
+			"ApprovedRevsHooks::deleteRevisionApproval"
+		],
+		"MagicWordwgVariableIDs": [
+			"ApprovedRevsHooks::addMagicWordVariableIDs"
+		],
+		"ParserBeforeTidy": [
+			"ApprovedRevsHooks::handleMagicWords"
+		],
+		"AdminLinks": [
+			"ApprovedRevsHooks::addToAdminLinks"
+		],
+		"LoadExtensionSchemaUpdates": [
+			"ApprovedRevsHooks::describeDBSchema"
+		],
+		"EditPage::showEditForm:initial": [
+			"ApprovedRevsHooks::addWarningToEditPage"
+		],
+		"PageForms::HTMLBeforeForm": [
+			"ApprovedRevsHooks::addWarningToPFForm"
+		],
+		"ArticleViewHeader": [
+			"ApprovedRevsHooks::setArticleHeader",
+			"ApprovedRevsHooks::displayNotApprovedHeader"
+		],
+		"OutputPageBodyAttributes": [
+			"ApprovedRevsHooks::addBodyClass"
+		],
+		"wgQueryPages": [
+			"ApprovedRevsHooks::onwgQueryPages"
+		]
+	},
+	"config": {
+		"_prefix": "eg",
+		"ApprovedRevsNamespaces": [ 0, 2, 4, 10, 12 ],
+		"ApprovedRevsSelfOwnedNamespaces": [],
+		"ApprovedRevsBlankIfUnapproved": false,
+		"ApprovedRevsAutomaticApprovals": true,
+		"ApprovedRevsShowApproveLatest": false,
+		"ApprovedRevsShowNotApprovedMessage": false
+	},
+	"manifest_version": 1
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8,6 +8,7 @@
 	"approvedrevs-logname": "Revision approval log",
 	"approvedrevs-logdesc": "This is the log of revisions that have been approved.",
 	"approvedrevs-approve": "approve",
+	"approvedrevs-approver": "$1 approved this revision.",
 	"approvedrevs-unapprove": "unapprove",
 	"approvedrevs-approvesuccess": "This revision of the page has been set as the approved version.",
 	"approvedrevs-unapprovesuccess": "There is no longer an approved version for this page.\nInstead, the most recent revision will be shown.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -14,6 +14,7 @@
 	"approvedrevs-logname": "{{doc-logpage}}",
 	"approvedrevs-logdesc": "Used as heading in [[Special:Log]]/approvedrevs.",
 	"approvedrevs-approve": "Used as link text.\n\nThe URL of the link contains \"action=approve\".\n\nSee also:\n* {{msg-mw|Approvedrevs-unapprove}}\n{{Identical|Approve}}",
+	"approvedrevs-approver": "Used to show page approver.",
 	"approvedrevs-unapprove": "Used as link text.\n\nThe URL of the link contains \"action=unapprove\".\n\nSee also:\n* {{msg-mw|Approvedrevs-approve}}",
 	"approvedrevs-approvesuccess": "Used as success message.",
 	"approvedrevs-unapprovesuccess": "Used as success message.\n\nSee also:\n* {{msg-mw|Approvedrevs-unapprovesuccess2}}",

--- a/maintenance/ApprovedRevs.sql
+++ b/maintenance/ApprovedRevs.sql
@@ -1,6 +1,7 @@
 CREATE TABLE /*_*/approved_revs (
 	page_id int default NULL,
-	rev_id int default NULL
+	rev_id int default NULL,
+	appr_user int unsigned NOT NULL default 0
 ) /*$wgDBTableOptions*/;
 
 CREATE UNIQUE INDEX approved_revs_page_id ON /*_*/approved_revs (page_id);

--- a/patch-appr_user.sql
+++ b/patch-appr_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE /*_*/approved_revs
+  ADD COLUMN appr_user  int unsigned NOT NULL default 0;


### PR DESCRIPTION
This comes from a suggestion found here:
https://www.mediawiki.org/w/index.php?oldid=2427029#Who_approved_.28code_proposal.29

Introduce a new right—viewapprover—that manages the display of this information.

Bug: T186646
Change-Id: I9a6a8a96f895f7fe40b9ece9f40cd51830a6c3fa